### PR TITLE
Add 5m timeout to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
 
     - name: Checkout


### PR DESCRIPTION
Adds a 5 minute timeout to the GitHub actions CI script to ensure we don't use up all Docker's credits if something gets delayed