### PR TITLE
Add e2e test for building from private registry

### DIFF
--- a/e2e/login_test.go
+++ b/e2e/login_test.go
@@ -18,6 +18,7 @@ func TestLogin(t *testing.T) {
 }
 
 func loginLocalRegistry() error {
+	// Polls as registry takes a moment to start up
 	return wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
 		err := runActionsCommand("login", "testdata/login_test.env")
 		return err == nil, err

--- a/e2e/testdata/build_push_tests/build_push.env
+++ b/e2e/testdata/build_push_tests/build_push.env
@@ -6,6 +6,6 @@ INPUT_LABELS=a=a1
 INPUT_REGISTRY=localhost:5000
 INPUT_USERNAME=my_user
 INPUT_PASSWORD=my_password
-INPUT_REPOSITORY=my-repository
+INPUT_REPOSITORY=org/base
 INPUT_PUSH=true
 GITHUB_REF=refs/tags/build-push-tag1

--- a/e2e/testdata/build_push_tests/build_push_from_registry.env
+++ b/e2e/testdata/build_push_tests/build_push_from_registry.env
@@ -1,0 +1,11 @@
+INPUT_PATH=./testdata/build_push_tests
+INPUT_DOCKERFILE=./testdata/build_push_tests/fromreg.Dockerfile
+INPUT_TAG_WITH_REF=true
+INPUT_TAGS=build-push-reg-test
+INPUT_LABELS=b=b1
+INPUT_REGISTRY=localhost:5000
+INPUT_USERNAME=my_user
+INPUT_PASSWORD=my_password
+INPUT_REPOSITORY=org/repo
+INPUT_PUSH=true
+GITHUB_REF=refs/tags/build-push-reg-tag1

--- a/e2e/testdata/build_push_tests/fromreg.Dockerfile
+++ b/e2e/testdata/build_push_tests/fromreg.Dockerfile
@@ -1,0 +1,3 @@
+FROM localhost:5000/org/base:build-push-test
+
+ENTRYPOINT ["echo", "hello-world build-push-from-registry"]


### PR DESCRIPTION
Updates the e2e test for building from a private registry during build-push. First build and push a base image and remove it locally then build and push an image based on it.