### PR TITLE
chore: support --cache-from arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Builds and tags a docker image.
 |INPUT_TARGET|no|Target build stage to build|
 |INPUT_BUILD_ARGS|no|Comma-delimited list of build-args|
 |INPUT_LABELS|no|Comma-delimited list of labels|
+|INPUT_CACHE_FROMS|no|Comma-delimited list of cache-froms|
 
 See the tagging section for information on tag inputs
 

--- a/internal/command/args.go
+++ b/internal/command/args.go
@@ -29,6 +29,10 @@ func BuildArgs(o options.Build, github options.GitHub, tags []string) []string {
 		args = append(args, "--file", o.Dockerfile)
 	}
 
+	if o.CacheFrom != "" {
+		args = append(args, "--cache-from", o.CacheFrom)
+	}
+
 	if o.Target != "" {
 		args = append(args, "--target", o.Target)
 	}

--- a/internal/command/args.go
+++ b/internal/command/args.go
@@ -29,16 +29,16 @@ func BuildArgs(o options.Build, github options.GitHub, tags []string) []string {
 		args = append(args, "--file", o.Dockerfile)
 	}
 
-	if o.CacheFrom != "" {
-		args = append(args, "--cache-from", o.CacheFrom)
-	}
-
 	if o.Target != "" {
 		args = append(args, "--target", o.Target)
 	}
 
 	if o.AlwaysPull {
 		args = append(args, "--pull")
+	}
+
+	for _, cacheFrom := range o.CacheFroms {
+		args = append(args, "--cache-from", cacheFrom)
 	}
 
 	for _, buildArg := range o.BuildArgs {

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -80,10 +80,10 @@ func TestBuildArgs(t *testing.T) {
 		{
 			name: "with-cache-from",
 			build: options.Build{
-				Path:      ".",
-				CacheFrom: "foo/bar",
+				Path:       ".",
+				CacheFroms: []string{"foo/bar-1", "foo/bar-2"},
 			},
-			expected: []string{"build", "--progress", "plain", "--cache-from", "foo/bar", "."},
+			expected: []string{"build", "--progress", "plain", "--cache-from", "foo/bar-1", "--cache-from", "foo/bar-2", "."},
 		},
 	}
 	for _, tc := range testCases {

--- a/internal/command/args_test.go
+++ b/internal/command/args_test.go
@@ -77,6 +77,14 @@ func TestBuildArgs(t *testing.T) {
 			},
 			expected: []string{"build", "--progress", "plain", "--build-arg", "build-arg-1", "--build-arg", "build-arg-2", "."},
 		},
+		{
+			name: "with-cache-from",
+			build: options.Build{
+				Path:      ".",
+				CacheFrom: "foo/bar",
+			},
+			expected: []string{"build", "--progress", "plain", "--cache-from", "foo/bar", "."},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/internal/options/build.go
+++ b/internal/options/build.go
@@ -17,7 +17,7 @@ type Build struct {
 	AddGitLabels bool   `env:"INPUT_ADD_GIT_LABELS"`
 	Target       string `env:"INPUT_TARGET"`
 	AlwaysPull   bool   `env:"INPUT_ALWAYS_PULL"`
-	CacheFrom    string `env:"INPUT_CACHE_FROM"`
+	CacheFroms   []string
 	BuildArgs    []string
 	Labels       []string
 }
@@ -27,6 +27,10 @@ func GetBuildOptions() (Build, error) {
 	var build Build
 	if err := env.Parse(&build); err != nil {
 		return build, err
+	}
+
+	if cacheFroms := os.Getenv("INPUT_CACHE_FROMS"); cacheFroms != "" {
+		build.CacheFroms = strings.Split(cacheFroms, ",")
 	}
 
 	if buildArgs := os.Getenv("INPUT_BUILD_ARGS"); buildArgs != "" {

--- a/internal/options/build.go
+++ b/internal/options/build.go
@@ -17,6 +17,7 @@ type Build struct {
 	AddGitLabels bool   `env:"INPUT_ADD_GIT_LABELS"`
 	Target       string `env:"INPUT_TARGET"`
 	AlwaysPull   bool   `env:"INPUT_ALWAYS_PULL"`
+	CacheFrom    string `env:"INPUT_CACHE_FROM"`
 	BuildArgs    []string
 	Labels       []string
 }

--- a/internal/options/build_test.go
+++ b/internal/options/build_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetBuildOptions(t *testing.T) {
 	_ = os.Setenv("INPUT_PATH", "path")
 	_ = os.Setenv("INPUT_DOCKERFILE", "dockerfile")
-	_ = os.Setenv("INPUT_CACHE_FROM", "foo/bar")
+	_ = os.Setenv("INPUT_CACHE_FROMS", "foo/bar-1,foo/bar-2")
 	_ = os.Setenv("INPUT_REPOSITORY", "repository")
 	_ = os.Setenv("INPUT_BUILD_ARGS", "buildarg1=b1,buildarg2=b2")
 	_ = os.Setenv("INPUT_LABELS", "label1=l1,label2=l2")
@@ -30,7 +30,7 @@ func TestGetBuildOptions(t *testing.T) {
 		AlwaysPull: true,
 		BuildArgs:  []string{"buildarg1=b1", "buildarg2=b2"},
 		Labels:     []string{"label1=l1", "label2=l2"},
-		CacheFrom:  "foo/bar",
+		CacheFroms: []string{"foo/bar-1", "foo/bar-2"},
 	}, o)
 }
 

--- a/internal/options/build_test.go
+++ b/internal/options/build_test.go
@@ -12,6 +12,7 @@ import (
 func TestGetBuildOptions(t *testing.T) {
 	_ = os.Setenv("INPUT_PATH", "path")
 	_ = os.Setenv("INPUT_DOCKERFILE", "dockerfile")
+	_ = os.Setenv("INPUT_CACHE_FROM", "foo/bar")
 	_ = os.Setenv("INPUT_REPOSITORY", "repository")
 	_ = os.Setenv("INPUT_BUILD_ARGS", "buildarg1=b1,buildarg2=b2")
 	_ = os.Setenv("INPUT_LABELS", "label1=l1,label2=l2")
@@ -29,6 +30,7 @@ func TestGetBuildOptions(t *testing.T) {
 		AlwaysPull: true,
 		BuildArgs:  []string{"buildarg1=b1", "buildarg2=b2"},
 		Labels:     []string{"label1=l1", "label2=l2"},
+		CacheFrom:  "foo/bar",
 	}, o)
 }
 


### PR DESCRIPTION
Improve docker build speed. See the repo: https://github.com/go-training/docker-in-github-actions-vs-drone

```dockerfile
FROM golang:1.14-alpine

LABEL maintainer="Bo-Yi Wu <appleboy.tw@gmail.com>"

RUN apk add bash ca-certificates git gcc g++ libc-dev
WORKDIR /app
# Force the go compiler to use modules
ENV GO111MODULE=on
# We want to populate the module cache based on the go.{mod,sum} files.
COPY go.mod .
COPY go.sum .
COPY main.go .

ENV GOOS=linux
ENV GOARCH=amd64
RUN go build -o /app -tags netgo -ldflags '-w -extldflags "-static"' .

CMD ["/app"]
```

## GitHub Actions

```yml
- name: build and push image
  uses: docker/build-push-action@v1
  with:
    username: ${{ secrets.DOCKER_USERNAME }}
    password: ${{ secrets.DOCKER_PASSWORD }}
    repository: appleboy/gin-docker-demo
    dockerfile: Dockerfile
    always_pull: true
    tags: latest
```

## Drone CI

```yml
- name: publish
  pull: always
  image: plugins/docker:linux-amd64
  settings:
    auto_tag: true
    cache_from: appleboy/gin-docker-demo
    daemon_off: false
    dockerfile: Dockerfile
    password:
      from_secret: docker_password
    repo: appleboy/gin-docker-demo
    username:
      from_secret: docker_username
  when:
    event:
      exclude:
      - pull_request
```

## Summary

build time

* GitHub Actions: 1m10s ([logs](https://github.com/go-training/docker-in-github-actions-vs-drone/runs/542876427?check_suite_focus=true))
* Drone CI: **17s** ([logs](https://cloud.drone.io/go-training/docker-in-github-actions-vs-drone/14/1/2))